### PR TITLE
disable qmake test if qt is static

### DIFF
--- a/recipes/qt/5.x.x/test_package/conanfile.py
+++ b/recipes/qt/5.x.x/test_package/conanfile.py
@@ -28,7 +28,12 @@ class TestPackageConan(ConanFile):
             not tools.os_info.is_macos and\
             not self._is_mingw()
 
+    def _qmake_supported(self):
+        return self.options["qt"].shared
+
     def _build_with_qmake(self):
+        if not self._qmake_supported():
+            return
         tools.mkdir("qmake_folder")
         with tools.chdir("qmake_folder"):
             self.output.info("Building with qmake")
@@ -94,6 +99,8 @@ class TestPackageConan(ConanFile):
         self._build_with_cmake_find_package_multi()
 
     def _test_with_qmake(self):
+        if not self._qmake_supported():
+            return
         self.output.info("Testing qmake")
         bin_path = os.path.join("qmake_folder", "bin")
         if tools.os_info.is_macos:


### PR DESCRIPTION
some paths to dependencies are hard-coded in this case